### PR TITLE
Fix board info mutation bug

### DIFF
--- a/game_logic/game/_reports.py
+++ b/game_logic/game/_reports.py
@@ -34,7 +34,9 @@ def generate_board_info(self):
                           'desertable': self.can_put_desert(self.current_player, s_id)}
                    for s_id, s in self.spaces.items()},
         }
-    info["spaces"][1]["camels"] += self.final_space.camels
+    info["spaces"][1]["camels"] = (
+        info["spaces"][1]["camels"] + list(self.final_space.camels)
+    )
     info["last_bet_winner"] = self.last_bet_winner
     info["last_bet_loser"] = self.last_bet_loser
     return info


### PR DESCRIPTION
## Summary
- avoid mutating game state when generating board info

## Testing
- `python -m py_compile game_logic/game/_reports.py`
- `python -m compileall -q game_logic`


------
https://chatgpt.com/codex/tasks/task_e_684433ee5a2c83239f540879a1064b22