### PR TITLE
Fix message in update_board_info

### DIFF
--- a/game_logic/game/_communicate.py
+++ b/game_logic/game/_communicate.py
@@ -53,7 +53,7 @@ def update_leg_betting_info(self, room=None):
     self.emit_info("betting-tiles", info, room)
 
 def update_board_info(self, room=None):
-    print("Sending update player info")
+    print("Sending update board info")
     info = self.generate_board_info()
     info.update(self.generate_leg_betting_info())
     self.emit_info("board", info, room)


### PR DESCRIPTION
## Summary
- update `update_board_info` log message to mention board rather than player

## Testing
- `python -m py_compile game_logic/game/_communicate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684434fe48d88323b592ce77bde20141