### PR TITLE
Add unit tests and adjust move logic

### DIFF
--- a/game_logic/game/_actions.py
+++ b/game_logic/game/_actions.py
@@ -27,7 +27,7 @@ def move(self, camel_name, steps):
     if self.spaces[new_pos].desert_state != 0:
         self.spaces[new_pos].desert_player.earn_points(1, "owning the desert")
         new_pos += self.spaces[new_pos].desert_state
-    if new_pos >= (len(self.spaces) - 1):
+    if new_pos > len(self.spaces):
         self.move_camel_to_space(camel_name, 17)
         self.declare_winning_camel()
         return

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -vv
+python_files = test_*.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))

--- a/tests/test_game_move.py
+++ b/tests/test_game_move.py
@@ -1,0 +1,19 @@
+import pytest
+from game_logic.game import Game
+from game_logic.player import Player
+
+
+def test_move_to_space_16_not_end_game():
+    game = Game()
+    game.players['p1'] = Player('P1', 'p1')
+    game.move('white', 16)
+    assert game.winning_camel is None
+    assert game.camels['white'].position_id == 16
+
+
+def test_move_past_space_16_ends_game():
+    game = Game()
+    game.players['p1'] = Player('P1', 'p1')
+    game.move('white', 17)
+    assert game.winning_camel == 'white'
+    assert game.final_space.get_top_camel() == 'white'

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -1,0 +1,13 @@
+from game_logic.space import Space
+
+
+def test_get_top_camel_empty():
+    space = Space(1)
+    assert space.get_top_camel() is None
+
+
+def test_get_top_camel_stack():
+    space = Space(1)
+    space.append_camel('white')
+    space.append_camel('blue')
+    assert space.get_top_camel() == 'blue'


### PR DESCRIPTION
## Summary
- configure pytest for repository
- test `Game.move` behaviour around space 16
- test `Space.get_top_camel`
- fix `Game.move` to only finish the game when a camel moves past the last space

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684435083f088323998bdc449293a0a2